### PR TITLE
plugin: only create a src ghost pad

### DIFF
--- a/plugin/gstplayer.cpp
+++ b/plugin/gstplayer.cpp
@@ -442,7 +442,11 @@ void QtGstPlayer::updatePipeline()
 	else {
 		source.remove(0, prefix.length());
 		m_pipeline = gst_pipeline_new("QtGstPlayer");
-		GstElement *sourceBin = gst_parse_bin_from_description(source.toLatin1().data(), true, NULL);
+		GstElement *sourceBin = gst_parse_bin_from_description(source.toLatin1().data(), false, NULL);
+		if (GstPad *pad = gst_bin_find_unlinked_pad(GST_BIN(sourceBin), GST_PAD_SRC); pad) {
+			gst_element_add_pad(sourceBin, gst_ghost_pad_new("src", pad));
+			gst_object_unref(pad);
+		}
 		gst_bin_add_many(GST_BIN(m_pipeline), sourceBin, sinkBin, NULL);
 		gst_element_link(sourceBin, sinkBin);
 	}


### PR DESCRIPTION
Only create a src ghost pad for the pipeline bin to avoid linking an unused sink ghost pad, as this may break delayed linking attempts.

The second argument from gst_parse_bin_from_description enables an automatic creation and linking of ghost pads. In the usual case only a src ghost pad is created, as a potential sink is not necessary and will not be linked to anything.

But in case of a (video) demux element linked with a consumer, the initial linking fails, due the demux element not knowing the streams and therefore not providing any src pads. As the consumer pad is not linked, a sink ghost pad is created and linked. When the demux element knows what streams it has, it creates its src pads and a delayed linking occurs. But as the consumer is already linked, the intended link with the demux element fails.

To avoid this error, we avoid the automatic ghost pad creation and instead manually create the src ghost pad.